### PR TITLE
Small fixes and changes.

### DIFF
--- a/2dclas/particle.py
+++ b/2dclas/particle.py
@@ -79,7 +79,7 @@ class Particle():
         return rlater
     
     def RKF(self,r):
-        eps = 0.000001
+        eps = 0.00000001
 
         hnew = self.dt
         safety = 0

--- a/2dclas/potentials.py
+++ b/2dclas/potentials.py
@@ -80,12 +80,18 @@ def woodsaxon(r,param):
     V0 = param[2]
     Rx = param[3]
     Ry = param[4]
-    a = param[5]
+    theta = param[5]*(np.pi/180.)
+    
+    a = 1.
     
     x = r[0] - x0
-    px = np.sqrt(x**2)
     y = r[1] - y0
-    py = np.sqrt(y**2)
+    
+    xr = x*np.cos(theta) - y*np.sin(theta)
+    yr = x*np.sin(theta) + y*np.cos(theta)
+    
+    px = np.sqrt(xr**2)
+    py = np.sqrt(yr**2)
     
     f = V0*(1/(1 + np.exp((px-Rx)/a)))*(1/(1 + np.exp((py-Ry)/a)))
     
@@ -97,12 +103,18 @@ def dwoodsaxonx(r,param):
     V0 = param[2]
     Rx = param[3]
     Ry = param[4]
-    a = param[5]
+    theta = param[5]*(np.pi/180.)
+    
+    a = 1.
     
     x = r[0] - x0
-    px = np.sqrt(x**2)
     y = r[1] - y0
-    py = np.sqrt(y**2)
+    
+    xr = x*np.cos(theta) - y*np.sin(theta)
+    yr = x*np.sin(theta) + y*np.cos(theta)
+    
+    px = np.sqrt(xr**2)
+    py = np.sqrt(yr**2)
     
     sign = np.where(x>0,1,-1)
     
@@ -115,12 +127,18 @@ def dwoodsaxony(r,param):
     V0 = param[2]
     Rx = param[3]
     Ry = param[4]
-    a = param[5]
+    theta = param[5]*(np.pi/180.)
+    
+    a = 1.
     
     x = r[0] - x0
-    px = np.sqrt(x**2)
     y = r[1] - y0
-    py = np.sqrt(y**2)
+    
+    xr = x*np.cos(theta) - y*np.sin(theta)
+    yr = x*np.sin(theta) + y*np.cos(theta)
+    
+    px = np.sqrt(xr**2)
+    py = np.sqrt(yr**2)
     
     sign = np.where(y>0,1,-1)
     

--- a/2dclas/sim.kv
+++ b/2dclas/sim.kv
@@ -3,6 +3,8 @@
 <main>:
 	orientation: 'horizontal'
 
+	pcbutton: pc_button.__self__
+
 	param0slider: param0_slider.__self__
 	param1slider: param1_slider.__self__
 
@@ -55,8 +57,9 @@
 			size_hint: (1, 0.1)
 			orientation: 'horizontal'
 			Button:
-				text: 'Play'
-				on_press: root.play()
+				id: pc_button
+				text: 'Compute'
+				on_press: root.playcompute()
 			Button:
 				text: 'Pause'
 				on_press: root.pause()
@@ -69,11 +72,11 @@
 		BoxLayout:
 			size_hint: (1, 0.1)
 			orientation: 'horizontal'
-			Button:
-				text: 'Compute'
-				on_press: root.compute()
+			Label:
+				text: 'Status:'
 			Label:
 				id: status_label
+				text: 'Ready'
 			Button:
 				text: 'Save'
 				on_press: root.save()
@@ -229,7 +232,7 @@
 								BoxLayout:
 									orientation: 'horizontal'
 									Label:
-										text: 'a'
+										text: 'Theta'
 										markup: True
 										size_hint: (0.2, 1)
 									Label:
@@ -238,9 +241,9 @@
 									Slider:
 										id: param5ws_slider
 										size_hint: (1, 1)
-										min: 0.3
-										max: 1
-										step: 0.1								
+										min: 0
+										max: 180
+										step: 1								
 			TabbedPanelItem:
 				text: 'Particles'
 				id: part_tab


### PR DESCRIPTION
- Merged the compute and play button: now it is not possible to hit play without computing if a new potential/particle has been added. This fixes a bug where pressing play before computing would crash the application.
- Reworked the status label to be text only. Right now it only shows ready or not ready with no feedback during computation. A solution to this is in the works.
- Woods-Saxon potential no longer has the slope parameter 'a' as an option (it now is 1. always). Instead an angle of rotation has been added, however the physics of the particles colliding with rotated rectangles don't seem to be correct (the reflection law, for example, is not reproduced). This may or may not be an artifact of trying to simulate collisions with potentials, it needs to be investigated in more detail.