### PR TITLE
Petit canvi a README.md a instruccions per crear clavsqua_env

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ pip install kivy.deps.gstreamer==0.1.12
 
 pip install kivy.deps.sdl2==0.1.17
 
-garden install matplotlib
+garden install matplotlib --kivy
 
 pip install numba
 


### PR DESCRIPTION
Afegir --kivy a:
garden install matplotlib

Això permet més tard, si cal, crear executables amb PyInstaller fàcilment, si no no es detecta garden. (Tampoc PyCharm o altres IDEs detecten garden sense --kivy, encara que corrin igual)